### PR TITLE
Adds a TypeScript definition file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ found to appropriate types. It supports:
  - Default values when environment variables should be optional.
  - Required values when environment variables are not optional.
 
+For compatibility with babel and TypeScript, this module re-exports itself as
+default and provides a TypeScript definition file.
+
 ### Usage
 
 Configeur accepts an object which defines config variables names and how to

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,17 @@
+interface EnvironmentSpec {
+  defaultValue?: string;
+  required?: boolean;
+  type?: string;
+}
+
+interface Environment {
+  [propName: string]: EnvironmentSpec;
+}
+
+type Parser = [string, (string) => any];
+
+interface Options {
+  parsers?: Parser[]
+}
+
+export default function configeur(environment: Environment, options?: Options): Object;

--- a/index.js
+++ b/index.js
@@ -6,3 +6,5 @@ const makeParsers = require('./lib/makeParsers');
 module.exports = function configeur(schema, options = {}) {
   return processConfig(schema, process.env, makeParsers(options.parsers));
 };
+
+module.exports.default = module.exports;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "description": "Extensible parsing of environment variables into config.",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "mocha --recursive"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -36,6 +36,10 @@ describe('configeur', () => {
     assert.strictEqual(typeof configeur, 'function');
   });
 
+  it('re-exports itself as default', () => {
+    assert.equal(configeur.default, configeur);
+  });
+
   it('returns a config map', () => {
     assert.strictEqual(configeur('fakeSchema'), 'fakeProcessedConfig');
   });


### PR DESCRIPTION
This PR also has configeur re-export itself as `exports.default` for compatibility with things like TypeScript and Babel.